### PR TITLE
Convert invalid top level text nodes to paragraph nodes

### DIFF
--- a/src/htmlStringToDocument.ts
+++ b/src/htmlStringToDocument.ts
@@ -13,6 +13,7 @@ import {
   Text,
   Inline,
   Block,
+  BLOCKS,
 } from "@contentful/rich-text-types";
 import type {
   HTMLNode,
@@ -98,5 +99,26 @@ export const htmlStringToDocument = (
   const richTextNodes = parsedHtml.flatMap((node) =>
     mapHtmlNodeToRichTextNode(node, [], optionsWithDefaults),
   );
-  return createDocumentNode(richTextNodes as TopLevelBlock[]);
+
+  const richTextNodesWithTopLevelTextNodesConverted: TopLevelBlock[] =
+    richTextNodes.map((node) => {
+      if (node.nodeType === "text") {
+        return {
+          data: {},
+          nodeType: BLOCKS.PARAGRAPH,
+          content: [
+            {
+              ...node,
+              nodeType: "text",
+            },
+          ],
+        };
+      }
+
+      //TODO: Remove this type assertion.
+      // Other possible non-top level blocks are: LIST_ITEM, TABLE_ROW, TABLE_CELL and TABLE_HEADER_CELL
+      return node as TopLevelBlock;
+    });
+
+  return createDocumentNode(richTextNodesWithTopLevelTextNodesConverted);
 };

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1,4 +1,12 @@
-import { Block, BLOCKS, Inline, Mark, Text } from "@contentful/rich-text-types";
+import {
+  Block,
+  BLOCKS,
+  Inline,
+  Mark,
+  Text,
+  TopLevelBlock,
+  TopLevelBlockEnum,
+} from "@contentful/rich-text-types";
 import { getAsList } from "../utils";
 
 export const createText = (value: string, marks?: Mark | Mark[]): Text => {

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -112,4 +112,84 @@ describe("Parse HTML string to Contentful Document", () => {
 
     expect(htmlNodes).toMatchObject(matchNode);
   });
+
+  it("converts an invalid top level text node to a paragraph node", () => {
+    expect(
+      htmlStringToDocument("<div>Text under top level div</div>"),
+    ).toMatchObject({
+      content: [
+        {
+          data: {},
+          nodeType: BLOCKS.PARAGRAPH,
+          content: [
+            {
+              data: {},
+              marks: [],
+              nodeType: "text",
+              value: "Text under top level div",
+            },
+          ],
+        },
+      ],
+      data: {},
+      nodeType: "document",
+    });
+  });
+
+  it("handles a combination of valid top level nodes and top level text nodes.", () => {
+    expect(
+      htmlStringToDocument(
+        "Some unwrapped text prefixing a p tag." +
+          "<p>Paragraph content <span>I am a text node</span></p>" +
+          "Some unwrapped text suffixing a p tag",
+      ),
+    ).toMatchObject({
+      content: [
+        {
+          data: {},
+          nodeType: BLOCKS.PARAGRAPH,
+          content: [
+            {
+              data: {},
+              marks: [],
+              nodeType: "text",
+              value: "Some unwrapped text prefixing a p tag.",
+            },
+          ],
+        },
+        {
+          data: {},
+          nodeType: BLOCKS.PARAGRAPH,
+          content: [
+            {
+              data: {},
+              marks: [],
+              nodeType: "text",
+              value: "Paragraph content ",
+            },
+            {
+              data: {},
+              marks: [],
+              nodeType: "text",
+              value: "I am a text node",
+            },
+          ],
+        },
+        {
+          data: {},
+          nodeType: BLOCKS.PARAGRAPH,
+          content: [
+            {
+              data: {},
+              marks: [],
+              nodeType: "text",
+              value: "Some unwrapped text suffixing a p tag",
+            },
+          ],
+        },
+      ],
+      data: {},
+      nodeType: "document",
+    });
+  });
 });


### PR DESCRIPTION
Appreciate this tool, thanks for making it!

Recently I was using contentful-rich-text-html-parser on a piece of work where there was a need to use strings which sometimes wouldn't have a wrapping paragraph or other top level tag. (ex: `<div>Some text</div>` or `Some text with some <p>paragraph text</p>`

I noticed that the output of `htmlStringToDocument` doesn't match the contentful Document type in such cases. Instead a text node would be provided as a direct child of the document node. This doesn't match the contentful document type, and contentful rejects any content that's provided in this format. 

To get around this, I wound up writing some logic which maps over the document child nodes, finds any text nodes and then wraps them in a paragraph node, making the document valid. - I thought it might have some value here. 

This potentially has some impact on #188 where we see text nodes as child nodes of the document, though it doesn't try to do anything with whitespace. 

Also, I've just looked at the text nodes. This PR doesn't cover the other non-top-level-block types (LIST_ITEM, TABLE_ROW, TABLE_CELL and TABLE_HEADER_CELL). Happy to take a look at these once the approach here has been aligned.  

 