### PR TITLE
feat: add default tag converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,7 @@ const logAndConvertTagToChildren: TagConverter = (node, next) => {
 };
 
 const options: Options = {
-  convertTag: {
-    [DEFAULT_TAG_CONVERTER]: defaultConverter,
-  },
+  defaultTagConverter: logAndConvertTagToChildren,
 };
 
 htmlStringToDocument(htmlString, options);

--- a/README.md
+++ b/README.md
@@ -120,12 +120,38 @@ const converter = (node, next) => ({
 });
 ```
 
-Skipping an element can be done by returning the result of the `next`-function. Ignoring an element AND its' children can be done by just returning an empty array. **Skipping is the default behavior of any tag that is not supported.**
+Skipping an element can be done by returning the result of the `next`-function. Ignoring an element AND its' children can be done by just returning an empty array.
 
 ```typescript
 const skippingConverter = (node, next) => next(node);
 
 const ignoringConverter = (node, next) => [];
+```
+
+### Unsupported tags
+
+Skipping an element is the default behavior of any tag that is not supported. However, this can be overridden as follows:
+
+```typescript
+import {
+  DEFAULT_TAG_CONVERTER,
+  htmlStringToDocument,
+  Options,
+  TagConverter,
+} from "contentful-rich-text-html-parser";
+
+const defaultConverter: TagConverter = (node, next) => {
+  console.log(`Unsupported tag: ${node.tagName}`);
+  return next(node); // skip element
+};
+
+const options: Options = {
+  convertTag: {
+    [DEFAULT_TAG_CONVERTER]: defaultConverter,
+  },
+};
+
+htmlStringToDocument(htmlString, options);
 ```
 
 ### Example: Change all "div" elements to "p" elements

--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ Skipping an element is the default behavior of any tag that is not supported. Ho
 
 ```typescript
 import {
-  DEFAULT_TAG_CONVERTER,
   htmlStringToDocument,
   Options,
   TagConverter,
 } from "contentful-rich-text-html-parser";
+import { convertTagToChildren } from "contentful-rich-text-html-parser/converters";
 
-const defaultConverter: TagConverter = (node, next) => {
+const logAndConvertTagToChildren: TagConverter = (node, next) => {
   console.log(`Unsupported tag: ${node.tagName}`);
-  return next(node); // skip element
+  return convertTagToChildren(node, next); // skip element
 };
 
 const options: Options = {

--- a/src/htmlStringToDocument.ts
+++ b/src/htmlStringToDocument.ts
@@ -24,6 +24,8 @@ import type {
 import { createDocumentNode, getAsList, isNotNull } from "./utils";
 import { processConvertedNodesFromTopLevel } from "./processConvertedNodesFromTopLevel";
 
+export const DEFAULT_TAG_CONVERTER = "4e6caacc-4f71-404e-9936-cbcef2aece9e";
+
 const DEFAULT_TAG_CONVERTERS: Partial<
   Record<HTMLTagName, TagConverter<Block | Inline | Text>>
 > = {
@@ -76,7 +78,10 @@ const mapHtmlNodeToRichTextNode = (
     return convertText(node, marks);
   }
 
-  const tagConverter = convertTag?.[node.tagName] ?? convertTagToChildren;
+  const tagConverter =
+    convertTag?.[node.tagName] ??
+    convertTag?.[DEFAULT_TAG_CONVERTER] ??
+    convertTagToChildren;
   const convertedNode = tagConverter(node, next);
   return convertedNode;
 };

--- a/src/htmlStringToDocument.ts
+++ b/src/htmlStringToDocument.ts
@@ -24,8 +24,6 @@ import type {
 import { createDocumentNode, getAsList, isNotNull } from "./utils";
 import { processConvertedNodesFromTopLevel } from "./processConvertedNodesFromTopLevel";
 
-export const DEFAULT_TAG_CONVERTER = "4e6caacc-4f71-404e-9936-cbcef2aece9e";
-
 const DEFAULT_TAG_CONVERTERS: Partial<
   Record<HTMLTagName, TagConverter<Block | Inline | Text>>
 > = {
@@ -60,7 +58,7 @@ const mapHtmlNodeToRichTextNode = (
   marks: Mark[],
   options: OptionsWithDefaults,
 ) => {
-  const { convertText, convertTag } = options;
+  const { convertText, convertTag, defaultTagConverter } = options;
 
   const mapChildren: Next = (node, mark) => {
     const newMarks = mark ? getAsList(mark) : [];
@@ -78,10 +76,7 @@ const mapHtmlNodeToRichTextNode = (
     return convertText(node, marks);
   }
 
-  const tagConverter =
-    convertTag?.[node.tagName] ??
-    convertTag?.[DEFAULT_TAG_CONVERTER] ??
-    convertTagToChildren;
+  const tagConverter = convertTag[node.tagName] ?? defaultTagConverter;
   const convertedNode = tagConverter(node, next);
   return convertedNode;
 };
@@ -95,6 +90,7 @@ export const htmlStringToDocument = (
       ...DEFAULT_TAG_CONVERTERS,
       ...options.convertTag,
     },
+    defaultTagConverter: options.defaultTagConverter ?? convertTagToChildren,
     convertText: options.convertText ?? convertTextNodeToText,
     parserOptions: {
       handleWhitespaceNodes:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,4 @@
-export {
-  DEFAULT_TAG_CONVERTER,
-  htmlStringToDocument,
-} from "./htmlStringToDocument";
+export { htmlStringToDocument } from "./htmlStringToDocument";
 export type {
   HTMLElementNode,
   HTMLNode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-export { htmlStringToDocument } from "./htmlStringToDocument";
+export {
+  DEFAULT_TAG_CONVERTER,
+  htmlStringToDocument,
+} from "./htmlStringToDocument";
 export type {
   HTMLElementNode,
   HTMLNode,

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -8,10 +8,7 @@ import {
   TopLevelBlock,
   validateRichTextDocument,
 } from "@contentful/rich-text-types";
-import {
-  DEFAULT_TAG_CONVERTER,
-  htmlStringToDocument,
-} from "../htmlStringToDocument";
+import { htmlStringToDocument } from "../htmlStringToDocument";
 
 import { describe, expect, it } from "vitest";
 import { EXAMPLE_RICH_TEXT } from "./example";
@@ -107,7 +104,7 @@ describe("Parse unsupported tags", () => {
   });
 
   it("Uses default converter when specified", () => {
-    const defaultConverter: TagConverter<Block> = (node, next) => {
+    const toParagraphConverter: TagConverter<Block> = (node, next) => {
       return {
         nodeType: BLOCKS.PARAGRAPH,
         content: next(node),
@@ -118,9 +115,7 @@ describe("Parse unsupported tags", () => {
     const htmlNodes = htmlStringToDocument(
       `<custom-tag>${matchText}</custom-tag>`,
       {
-        convertTag: {
-          [DEFAULT_TAG_CONVERTER]: defaultConverter,
-        },
+        defaultTagConverter: toParagraphConverter,
       },
     );
 
@@ -129,7 +124,6 @@ describe("Parse unsupported tags", () => {
     ] as TopLevelBlock[]);
 
     expect(htmlNodes).toMatchObject(matchNode);
-    console.log(validateRichTextDocument(htmlNodes));
     expect(validateRichTextDocument(htmlNodes).length).toEqual(0);
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export interface PostProcessingOptions {
 
 export interface OptionsWithDefaults {
   convertTag: ConvertTagOptions;
+  defaultTagConverter: TagConverter;
   convertText: TextConverter;
   parserOptions: ParserOptions;
   postProcessing: PostProcessingOptions;


### PR DESCRIPTION
WHAT?

Allow to specify a default tag converter.

WHY?

The default behavior for unsupported tags, while useful is not flexible enough for some use cases (e.g. logging, failing, to convert, etc).

HOW?

`npm test && npm run build && npm run lint:fix`