### PR TITLE
feat: add async implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,20 @@
       "import": "./dist/es/index.js",
       "require": "./dist/cjs/index.js"
     },
+    "./async": {
+      "types": "./dist/types/indexAsync.d.ts",
+      "import": "./dist/es/indexAsync.js",
+      "require": "./dist/cjs/indexAsync.js"
+    },
     "./converters": {
-      "types": "./dist/types/converters.d.ts",
-      "import": "./dist/es/converters.js",
-      "require": "./dist/cjs/converters.js"
+      "types": "./dist/types/convertersSync.d.ts",
+      "import": "./dist/es/convertersSync.js",
+      "require": "./dist/cjs/convertersSync.js"
+    },
+    "./converters/async": {
+      "types": "./dist/types/convertersAsync.d.ts",
+      "import": "./dist/es/convertersAsync.js",
+      "require": "./dist/cjs/convertersAsync.js"
     }
   },
   "types": "./dist/types/index.d.ts",

--- a/src/convertersAsync.ts
+++ b/src/convertersAsync.ts
@@ -1,0 +1,28 @@
+import { Block } from "@contentful/rich-text-types";
+import {
+  createConvertTagToBlock,
+  convertTagToChildren as convertTagToChildrenImpl,
+  createConvertTagToHyperlink,
+  createConvertTagToInline,
+  convertTagToMark as convertTagToMarkImpl,
+  convertTextNodeToText as convertTextNodeToTextImpl,
+  createConvertTextNodeToParagraphedText,
+} from "./converters";
+import type { AsyncTagConverter, AsyncTextConverter } from "types";
+
+export const convertTagToBlock = createConvertTagToBlock(true);
+
+export const convertTagToInline = createConvertTagToInline(true);
+
+export const convertTagToHyperlink = createConvertTagToHyperlink(true);
+
+export const convertTagToMark = convertTagToMarkImpl as AsyncTagConverter;
+
+export const convertTagToChildren =
+  convertTagToChildrenImpl as AsyncTagConverter<Block>;
+
+export const convertTextNodeToText =
+  convertTextNodeToTextImpl as AsyncTextConverter;
+
+export const convertTextNodeToParagraphedText =
+  createConvertTextNodeToParagraphedText(true);

--- a/src/convertersSync.ts
+++ b/src/convertersSync.ts
@@ -1,0 +1,27 @@
+import { Block } from "@contentful/rich-text-types";
+import {
+  createConvertTagToBlock,
+  convertTagToChildren as convertTagToChildrenImpl,
+  createConvertTagToHyperlink,
+  createConvertTagToInline,
+  convertTagToMark as convertTagToMarkImpl,
+  convertTextNodeToText as convertTextNodeToTextImpl,
+  createConvertTextNodeToParagraphedText,
+} from "./converters";
+import type { TagConverter, TextConverter } from "./types";
+
+export const convertTagToBlock = createConvertTagToBlock(false);
+
+export const convertTagToInline = createConvertTagToInline(false);
+
+export const convertTagToHyperlink = createConvertTagToHyperlink(false);
+
+export const convertTagToMark = convertTagToMarkImpl as TagConverter;
+
+export const convertTagToChildren =
+  convertTagToChildrenImpl as TagConverter<Block>;
+
+export const convertTextNodeToText = convertTextNodeToTextImpl as TextConverter;
+
+export const convertTextNodeToParagraphedText =
+  createConvertTextNodeToParagraphedText(false);

--- a/src/htmlStringToDocumentAsync.ts
+++ b/src/htmlStringToDocumentAsync.ts
@@ -1,0 +1,10 @@
+import { Document } from "@contentful/rich-text-types";
+import { htmlStringToDocument as htmlStringToDocumentImpl } from "./htmlStringToDocument";
+import type { AsyncOptions } from "./types";
+
+export const htmlStringToDocument = (
+  htmlString: string,
+  options: AsyncOptions = {},
+): Promise<Document> => {
+  return htmlStringToDocumentImpl(true, htmlString, options);
+};

--- a/src/htmlStringToDocumentSync.ts
+++ b/src/htmlStringToDocumentSync.ts
@@ -1,0 +1,10 @@
+import { Document } from "@contentful/rich-text-types";
+import { htmlStringToDocument as htmlStringToDocumentImpl } from "./htmlStringToDocument";
+import type { Options } from "./types";
+
+export const htmlStringToDocument = (
+  htmlString: string,
+  options: Options = {},
+): Document => {
+  return htmlStringToDocumentImpl(false, htmlString, options);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { htmlStringToDocument } from "./htmlStringToDocument";
+export { htmlStringToDocument } from "./htmlStringToDocumentSync";
 export type {
   HTMLElementNode,
   HTMLNode,

--- a/src/indexAsync.ts
+++ b/src/indexAsync.ts
@@ -1,0 +1,12 @@
+export { htmlStringToDocument } from "./htmlStringToDocumentAsync";
+export type {
+  HTMLElementNode,
+  HTMLNode,
+  HTMLTextNode,
+  HTMLTagName,
+  AsyncOptions as Options,
+  AsyncConvertTagOptions as ConvertTagOptions,
+  AsyncTagConverter as TagConverter,
+  AsyncTextConverter as TextConverter,
+  AsyncNext as Next,
+} from "./types";

--- a/src/processConvertedNodesFromTopLevel.ts
+++ b/src/processConvertedNodesFromTopLevel.ts
@@ -5,7 +5,7 @@ import {
   Text,
   TopLevelBlock,
 } from "@contentful/rich-text-types";
-import type { OptionsWithDefaults } from "./types";
+import type { PostProcessingOptions } from "./types";
 import {
   isNodeTypeBlock,
   isNodeTypeInline,
@@ -15,7 +15,7 @@ import {
 
 export const processConvertedNodesFromTopLevel = (
   node: Block | Inline | Text,
-  options: OptionsWithDefaults,
+  options: PostProcessingOptions,
 ): TopLevelBlock | null => {
   if (isNodeTypeBlock(node)) {
     if (isNodeTypeTopLevelBlock(node)) {
@@ -29,10 +29,10 @@ export const processConvertedNodesFromTopLevel = (
     return node as unknown as TopLevelBlock;
   }
   if (isNodeTypeInline(node)) {
-    if (options.postProcessing.handleTopLevelInlines === "remove") {
+    if (options.handleTopLevelInlines === "remove") {
       return null;
     }
-    if (options.postProcessing.handleTopLevelInlines === "wrap-paragraph") {
+    if (options.handleTopLevelInlines === "wrap-paragraph") {
       return {
         nodeType: BLOCKS.PARAGRAPH,
         data: {},
@@ -42,10 +42,10 @@ export const processConvertedNodesFromTopLevel = (
     return node as unknown as TopLevelBlock;
   }
   if (isNodeTypeText(node)) {
-    if (options.postProcessing.handleTopLevelText === "remove") {
+    if (options.handleTopLevelText === "remove") {
       return null;
     }
-    if (options.postProcessing.handleTopLevelText === "wrap-paragraph") {
+    if (options.handleTopLevelText === "wrap-paragraph") {
       return {
         nodeType: BLOCKS.PARAGRAPH,
         data: {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,8 +43,18 @@ export type Next<TNodeType extends AnyContentfulNode = Block | Inline | Text> =
     node: HTMLNode,
     marks?: Mark | Mark[],
   ) => Array<ContentfulNodeContent<TNodeType>>;
+export type AsyncNext<
+  TNodeType extends AnyContentfulNode = Block | Inline | Text,
+> = (
+  node: HTMLNode,
+  marks?: Mark | Mark[],
+) => MaybePromise<Array<ContentfulNodeContent<TNodeType>>>;
 
 export type TextConverter = (node: HTMLTextNode, marks: Mark[]) => Text;
+export type AsyncTextConverter = (
+  node: HTMLTextNode,
+  marks: Mark[],
+) => MaybePromise<Text>;
 
 export type TagConverter<
   TNodeType extends AnyContentfulNode = Block | Inline | Text,
@@ -52,8 +62,18 @@ export type TagConverter<
   node: HTMLElementNode,
   next: Next<TNodeType>,
 ) => ConverterResult<TNodeType>;
+export type AsyncTagConverter<
+  TNodeType extends AnyContentfulNode = Block | Inline | Text,
+> = (
+  node: HTMLElementNode,
+  next: AsyncNext<TNodeType>,
+) => MaybePromise<ConverterResult<TNodeType>>;
 
 export type ConvertTagOptions = Record<HTMLTagName | string, TagConverter>;
+export type AsyncConvertTagOptions = Record<
+  HTMLTagName | string,
+  AsyncTagConverter
+>;
 
 export type HandleWhitespaceNodes = "preserve" | "remove";
 export type HandleTopLevelText = "preserve" | "remove" | "wrap-paragraph";
@@ -68,17 +88,35 @@ export interface PostProcessingOptions {
   handleTopLevelText: HandleTopLevelText;
 }
 
-export interface OptionsWithDefaults {
+interface OptionsWithDefaultsBase<
+  ConvertTagOptions,
+  TagConverter,
+  TextConverter,
+> {
   convertTag: ConvertTagOptions;
   defaultTagConverter: TagConverter;
   convertText: TextConverter;
   parserOptions: ParserOptions;
   postProcessing: PostProcessingOptions;
 }
+export type OptionsWithDefaults = OptionsWithDefaultsBase<
+  ConvertTagOptions,
+  TagConverter,
+  TextConverter
+>;
+export type AsyncOptionsWithDefaults = OptionsWithDefaultsBase<
+  AsyncConvertTagOptions,
+  AsyncTagConverter,
+  AsyncTextConverter
+>;
 
-export type Options = Partial<
-  Omit<OptionsWithDefaults, "parserOptions" | "postProcessing"> & {
+type OptionsBase<T> = Partial<
+  Omit<T, "parserOptions" | "postProcessing"> & {
     parserOptions: Partial<ParserOptions>;
     postProcessing: Partial<PostProcessingOptions>;
   }
 >;
+export type Options = OptionsBase<OptionsWithDefaults>;
+export type AsyncOptions = OptionsBase<AsyncOptionsWithDefaults>;
+
+export type MaybePromise<T> = T | Promise<T>;


### PR DESCRIPTION
WHAT?

Add an async implementation of the library that can be used by appending `/async` to the import statements.

WHY?

Allow users of the library to implement async converters. This unlocks use cases such as converting `<img>` tags by uploading the images as Contentful assets.

HOW?

`npm run lint && npm test && npm run build`